### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.6</source>
+					<target>1.6</target>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Fixes compiler version issues to use Java 6 rather than Java 7. Many servers run Java 6, and Bukkit themselves even advise plugin developers to compile against Java 6. http://forums.bukkit.org/threads/common-mistakes.100544/ 
