### PR TITLE
Filter fields in plugin.yml from pom when compiling

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,3 +1,4 @@
 main: me.confuser.barapi.BarAPI
-name: BarAPI
-version: 2.0
+name: ${project.name}
+version: ${project.version}
+description: ${project.description}

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	<name>BarAPI</name>
+	<description>Allows plugins to control the boss health bar message</description>
 	<groupId>me.confuser</groupId>
 	<artifactId>BarAPI</artifactId>
 	<version>2.0</version>


### PR DESCRIPTION
This makes it so the version only needs to be updated once: in the pom. It also means if a fork uses a different name, it also has to be updated only once.
(You might also consider using the Maven release plugin and using snapshot versions between releases, this also tags releases using Git.)
