### PR TITLE
Add validation to seconds param in setMessage(player, message, seconds)

### DIFF
--- a/src/me/confuser/barapi/BarAPI.java
+++ b/src/me/confuser/barapi/BarAPI.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 
 import me.confuser.barapi.nms.FakeDragon;
 
+import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;


### PR DESCRIPTION
This PR is based on this issue:
https://github.com/confuser/BarAPI/issues/5

It prevents plugin authors from using this method with invalid arguments.
