### PR TITLE
Improved Timer

### DIFF
--- a/src/me/confuser/barapi/BarAPI.java
+++ b/src/me/confuser/barapi/BarAPI.java
@@ -205,7 +205,9 @@ public class BarAPI extends JavaPlugin implements Listener {
 	 *            It will be cut to that size automatically.
 	 * @param seconds
 	 *            The amount of seconds displayed by the timer.<br>
-	 *            Supports values from 1 (inclusive) to 200 (inclusive).
+	 *            Supports values above 1 (inclusive).
+	 * @throws IllegalArgumentException
+	 *             If seconds is zero or below.
 	 * @see BarAPI#setMessage(player, message, seconds)
 	 */
 	public static void setMessage(String message, int seconds) {
@@ -229,19 +231,19 @@ public class BarAPI extends JavaPlugin implements Listener {
 	 *            It will be cut to that size automatically.
 	 * @param seconds
 	 *            The amount of seconds displayed by the timer.<br>
-	 *            Supports values from 1 (inclusive) to {@link FakeDragon#MAX_HEALTH} (inclusive).
+	 *            Supports values above 1 (inclusive).
 	 * @throws IllegalArgumentException
-	 *             If seconds is not within valid bounds.
+	 *             If seconds is zero or below.
 	 */
 	public static void setMessage(final Player player, String message, int seconds) {
-		Validate.isTrue(seconds >= 0 && seconds <= FakeDragon.MAX_HEALTH, "Seconds must be between 1 and " + FakeDragon.MAX_HEALTH + " but was: ", seconds);
+		Validate.isTrue(seconds >= 0, "Seconds must be above 1 but was: ", seconds);
 		
 		FakeDragon dragon = getDragon(player, message);
 
 		dragon.name = cleanMessage(message);
 		dragon.health = FakeDragon.MAX_HEALTH;
 
-		final int dragonHealthMinus = FakeDragon.MAX_HEALTH / seconds;
+		final float dragonHealthMinus = FakeDragon.MAX_HEALTH / seconds;
 
 		cancelTimer(player);
 

--- a/src/me/confuser/barapi/nms/FakeDragon.java
+++ b/src/me/confuser/barapi/nms/FakeDragon.java
@@ -5,7 +5,7 @@ import me.confuser.barapi.Util;
 import org.bukkit.Location;
 
 public abstract class FakeDragon {
-	public static final int MAX_HEALTH = 200;
+	public static final float MAX_HEALTH = 200;
 	private int x;
 	private int y;
 	private int z;
@@ -37,7 +37,7 @@ public abstract class FakeDragon {
 		this.world = Util.getHandle(loc.getWorld());
 	}
 
-	public int getMaxHealth() {
+	public float getMaxHealth() {
 		return MAX_HEALTH;
 	}
 


### PR DESCRIPTION
The timer becomes imprecise the higher the max time is.
For example seconds=101
Due to integer rounding this timer will run 200 seconds. (101/200=1)

This PR fixes that by using float values as health.

This also removes the upper limit (200) from the timer.
