### PR TITLE
Make Enderdragon never visible above y=0

### DIFF
--- a/src/me/confuser/barapi/BarAPI.java
+++ b/src/me/confuser/barapi/BarAPI.java
@@ -371,7 +371,7 @@ public class BarAPI extends JavaPlugin implements Listener {
 
 	private static void sendDragon(FakeDragon dragon, Player player) {
 		Util.sendPacket(player, dragon.getMetaPacket(dragon.getWatcher()));
-		Util.sendPacket(player, dragon.getTeleportPacket(player.getLocation().add(0, -200, 0)));
+		Util.sendPacket(player, dragon.getTeleportPacket(player.getLocation().add(0, -300, 0)));
 	}
 
 	private static FakeDragon getDragon(Player player, String message) {
@@ -382,7 +382,7 @@ public class BarAPI extends JavaPlugin implements Listener {
 	}
 
 	private static FakeDragon addDragon(Player player, String message) {
-		FakeDragon dragon = Util.newDragon(message, player.getLocation().add(0, -200, 0));
+		FakeDragon dragon = Util.newDragon(message, player.getLocation().add(0, -300, 0));
 
 		Util.sendPacket(player, dragon.getSpawnPacket());
 
@@ -392,7 +392,7 @@ public class BarAPI extends JavaPlugin implements Listener {
 	}
 
 	private static FakeDragon addDragon(Player player, Location loc, String message) {
-		FakeDragon dragon = Util.newDragon(message, loc.add(0, -200, 0));
+		FakeDragon dragon = Util.newDragon(message, loc.add(0, -300, 0));
 
 		Util.sendPacket(player, dragon.getSpawnPacket());
 


### PR DESCRIPTION
This has been tested, and the EnderDragon is visible from y = 0 to above y = 255, and the dragon stays below the ground level. This is purely a cosmetic change.
